### PR TITLE
Define python3 as default interpreter on target

### DIFF
--- a/build/ansible/inventories/production/hosts.yml
+++ b/build/ansible/inventories/production/hosts.yml
@@ -19,6 +19,7 @@ sbcs:
     <machine-name>:
       ansible_host: <libresbc-machine-ip>
       nodeid: <unique-nodeid>
+      ansible_python_interpreter: /usr/bin/python3
   vars:
     homer: null
     logstash: null


### PR DESCRIPTION
With the change above you fix the python2 vs python3 pip3 install issues on target host.

If you didnt defined that, you got an error (default debian net-install comes with python2.7 as /usr/bin/python and this happend):

The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_pip_payload_8aamVy/ansible_pip_payload.zip/ansible/modules/packaging/language/pip.py", line 271, in <module>
ImportError: No module named pkg_resources
fatal: [sbc01.example.com]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "chdir": null,
            "editable": false,
            "executable": "pip3",
            "extra_args": null,
            "name": null,
            "requirements": "/opt/libresbc/0.5.7/liberator/requirements.txt",
            "state": "present",
            "umask": null,
            "version": null,
            "virtualenv": null,
            "virtualenv_command": "virtualenv",
            "virtualenv_python": null,
            "virtualenv_site_packages": false
        }
    },
    "msg": "Failed to import the required Python library (setuptools) on sbc01.example.com's Python /usr/bin/python. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"
}