### PR TITLE
build app_lua

### DIFF
--- a/build/ansible/roles/platform/tasks/kamailio.yml
+++ b/build/ansible/roles/platform/tasks/kamailio.yml
@@ -28,7 +28,7 @@
     remote_src: yes
 
 - name: build kamailio
-  shell: make cfg && make include_modules="jsonrpcs outbound ndb_redis regex utils tls" cfg && make all && make install
+  shell: make cfg && make include_modules="jsonrpcs outbound ndb_redis regex utils tls app_lua app_lua_sr" cfg && make all && make install
   args:
     executable: /bin/bash
     chdir: /usr/local/src/kamailio-5.5.1


### PR DESCRIPTION
i use the ansible deployment and i follow the docu to configure the sbc via json requests. after setting the access stuff it breaks trying to start kamailio.

```
/usr/local/etc/kamailio/access_srv09.cfg, error=ERROR: bad config file (4 errors) (parsing code: 1)



root@srv09:~# kamailio -c -f /usr/local/etc/kamailio/access_srv09.cfg
loading modules under config path: /usr/local/lib64/kamailio/modules
 0(12737) ERROR: <core> [core/sr_module.c:504]: ksr_locate_module(): could not find module <app_lua> in </usr/local/lib64/kamailio/modules>
 0(12737) CRITICAL: <core> [core/cfg.y:3683]: yyerror_at(): parse error in config file /usr/local/etc/kamailio/access_srv09.cfg, line 136, column 12-23: failed to load module
 0(12737) ERROR: <core> [core/modparam.c:178]: set_mod_param_regex(): No module matching <app_lua> found
 0(12737) CRITICAL: <core> [core/cfg.y:3686]: yyerror_at(): parse error in config file /usr/local/etc/kamailio/access_srv09.cfg, line 137, column 71: Can't set module parameter
 0(12737) ERROR: <core> [core/modparam.c:178]: set_mod_param_regex(): No module matching <app_lua> found
 0(12737) CRITICAL: <core> [core/cfg.y:3686]: yyerror_at(): parse error in config file /usr/local/etc/kamailio/access_srv09.cfg, line 138, column 71: Can't set module parameter
 0(12737) CRITICAL: <core> [core/cfg.y:3683]: yyerror_at(): parse error in config file /usr/local/etc/kamailio/access_srv09.cfg, line 139, column 11-15: Can't set config routing engine
```

i build the app_lua.so (it is not there - and why it is build from source?!)  - anyhow - here is the fix.