### PR TITLE
Add sipaddrs into outbound interconnection example

### DIFF
--- a/documents/Configuration-Examples.md
+++ b/documents/Configuration-Examples.md
@@ -242,6 +242,9 @@ Declare PBX as a gateway
   "desc": "PBX Server",
   "sipprofile": "internal",
   "distribution": "weight_based",
+  "sipaddrs": [
+    "10.10.10.20/32",
+  ],
   "rtpaddrs": [
     "10.10.10.20/32"
   ],


### PR DESCRIPTION
### Add missing sipaddrs parameter to interconnection

Without sipaddrs firewall is not correctly setup, and will not let SIP in traffic from PBX.

This PR improves the documentation so it example works out of the box with notables.

