### PR TITLE
fix: automatically regenerate XML configuration in sofiagw events

### DIFF
--- a/liberator/basemgr.py
+++ b/liberator/basemgr.py
@@ -508,6 +508,8 @@ class BaseEventHandler(Thread):
                         elif portion == _SOFIAGW_:
                             sipprofile = data.get('sipprofile')
                             _gateway = data.get('_gateway')
+                            # Regenerar configuración XML antes de enviar comandos
+                            fsinstance(data)
                             commands = [f'sofia profile {sipprofile} killgw {_gateway}', f'sofia profile {sipprofile} rescan', 'reloadxml']
                         elif portion == _OUTCNX_:
                             action = data.get('action')


### PR DESCRIPTION
## Problem
LibreSBC does not automatically regenerate FreeSWITCH XML configuration when a gateway is updated from the UI, causing changes not to be reflected in the telephony system.

## Root Cause
The sofiagw event in BaseEventHandler only sends commands to FreeSWITCH but does not regenerate the XML configuration.

## Solution
Add call to fsinstance(data) before sending commands to FreeSWITCH in the sofiagw event handling.

## Modified Files
- liberator/basemgr.py (lines 509-515)

## Evidence
- Gateway changes now automatically reflect in FreeSWITCH
- Eliminates "no such gateway" errors
- do_register: false configuration is applied correctly

Fixes: LibreSBC does not automatically regenerate FreeSWITCH XML configuration