### PR TITLE
fix(libreapi): handle optional secondary route in routing_table_agreement

### DIFF
--- a/liberator/libreapi.py
+++ b/liberator/libreapi.py
@@ -2547,9 +2547,10 @@ class RoutingTableModel(BaseModel):
                 primary = routes.get('primary')
                 secondary = routes.get('secondary')
                 load = routes.get('load')
-                for intconname in [primary, secondary]:
-                    if not rdbconn.exists(f'intcon:out:{intconname}'):
-                        raise ValueError('nonexistent outbound interconnect')
+                if not rdbconn.exists(f'intcon:out:{primary}'):
+                    raise ValueError('nonexistent outbound interconnect')
+                if secondary and not rdbconn.exists(f'intcon:out:{secondary}'):
+                    raise ValueError('nonexistent outbound interconnect')
                 values['routes'] = [primary, secondary, load]
         elif action==_QUERY:
             values.pop('routes', None)


### PR DESCRIPTION
## Problem

When creating a routing table with `action='route'` and `secondary=null`, the `routing_table_agreement` validator fails with `422 Unprocessable Entity` — **even when the primary interconnect exists**.

Root cause: the validator iterates over `[primary, secondary]` without filtering `None`:

```python
# Before (broken)
for intconname in [primary, secondary]:
    if not rdbconn.exists(f'intcon:out:{intconname}'):
        raise ValueError('nonexistent outbound interconnect')
```

When `secondary` is `None`, this checks `rdbconn.exists('intcon:out:None')` → always `0` → raises the error regardless of whether the primary interconnect is valid.

Reported and reproduced in issue #197.

## Fix

Validate `secondary` only when it is not `None`:

```python
# After (fixed)
if not rdbconn.exists(f'intcon:out:{primary}'):
    raise ValueError('nonexistent outbound interconnect')
if secondary and not rdbconn.exists(f'intcon:out:{secondary}'):
    raise ValueError('nonexistent outbound interconnect')
```

## Impact

Any user attempting to create a routing table without a secondary route (`secondary: null`) on v1.0.0 hits this bug. The fix is minimal and does not affect behavior when `secondary` is provided.

Closes #197