### PR TITLE
fix(basemgr): trailing newline in FreeSWITCH Backgrounding stderr check

### DIFF
--- a/liberator/basemgr.py
+++ b/liberator/basemgr.py
@@ -201,7 +201,7 @@ def fsinstance(data):
         fsrun = Popen(['/usr/local/bin/freeswitch', '-nc', '-reincarnate'], stdout=PIPE, stderr=PIPE)
         _, stderr = bdecode(fsrun.communicate())
 
-        if stderr and not stderr.endswith('Backgrounding.'):
+        if stderr and not stderr.endswith('Backgrounding.\n'):
             result = False
             stderr = stderr.replace('\n', '')
             logger.error(f"module=liberator, space=basemgr, action=fsinstance.fsrun, error={stderr}")


### PR DESCRIPTION
## Problem

`fsinstance()` in `basemgr.py` checks FreeSWITCH stderr to detect a successful background start:

```python
# Before
if stderr and not stderr.endswith('Backgrounding.'):
    result = False
    logger.error(...)
```

FreeSWITCH actually outputs `Backgrounding.\n` (with a trailing newline). The old check always evaluates to `True` on a normal startup, so every successful FreeSWITCH launch logs a false **ERROR** and sets `result = False`.

## Fix

```python
# After
if stderr and not stderr.endswith('Backgrounding.\n'):
```

One character change — matches the actual FreeSWITCH output.

## Notes

This bug was also independently identified in PR #179. This PR isolates the fix as a standalone, minimal change with no other modifications.