### PR TITLE
fix(callng): clear stale concurentcalls keys on FreeSWITCH startup

### DIFF
--- a/callng/event.startup.lua
+++ b/callng/event.startup.lua
@@ -24,7 +24,22 @@ end
 ---------------------******************************---------------------
 ---------------------*****|       MAIN       |*****---------------------
 ---------------------******************************---------------------
+local function cleanup_stale_concurentcalls()
+    -- FreeSWITCH startup: remove stale call-tracking keys left by a hard kill/crash
+    local pattern = 'realtime:concurentcalls:*:*:' .. NODEID
+    local cursor = '0'
+    repeat
+        local res = rdbconn:scan(cursor, 'MATCH', pattern, 'COUNT', 100)
+        cursor = res[1]
+        for _, key in ipairs(res[2]) do
+            rdbconn:del(key)
+            log.info('module=callng, space=event:startup, action=cleanup_stale_concurentcalls, key=%s', key)
+        end
+    until cursor == '0'
+end
+
 local function main()
+    cleanup_stale_concurentcalls()
     recovery()
 end
 -----


### PR DESCRIPTION
## Summary

When FreeSWITCH is killed with SIGKILL (crash, hard stop, OOM), active
channel UUIDs remain in the realtime:concurentcalls:* Redis sets with no
TTL. These orphaned entries make call counters report falsely high values
on the next startup and persist indefinitely.

On the STARTUP event, scan and delete all concurentcalls keys scoped to
the current NODEID. If FreeSWITCH is starting fresh, no real channels can
be active on this node, so clearing the keys is always safe.

## Context

Cherry-picked from a downstream deployment of LibreSBC. Commit `336488f`
on the local fork.

## Test plan

- [ ] Existing test suite passes.
- [ ] Manual verification on a non-prod deployment.