### PR TITLE
feat(libreapi+callng): add per-interconnect P-Asserted-Identity header

### DIFF
--- a/callng/main.lua
+++ b/callng/main.lua
@@ -205,6 +205,13 @@ local function main()
             -- outbound manipulation
             manipulate(InLeg, NgVars)
             --------------------------------------------------------------------
+            -- P-Asserted-Identity header
+            if fieldjsonify(rdbconn:hget(intconkey(NgVars.route, OUTBOUND), 'pai')) then
+                local _sipadip_pai = freeswitch.getGlobalVariable(_sipprofile..':advertising')
+                if not _sipadip_pai then _sipadip_pai = freeswitch.getGlobalVariable('hostname') end
+                InLeg:execute("export", "nolocal:sip_h_P-Asserted-Identity=<sip:"..NgVars.cidnumber.."@".._sipadip_pai..";user=phone>")
+            end
+            --------------------------------------------------------------------
 
             -- start outbound leg
             log.info('module=callng, space=main, action=connect_gateway, seshid=%s, uuid=%s, route=%s, sipprofile=%s, gateway=%s, algorithm=%s, forceroute=%s',

--- a/liberator/libreapi.py
+++ b/liberator/libreapi.py
@@ -1865,6 +1865,7 @@ class OutboundInterconnection(BaseModel):
     nofailover_sip_codes: Optional[List[SIPCode]] = Field(default=[], min_length=0, max_item=32, description='a set of sip response code that stop failover')
     nodes: List[str] = Field(default=['_ALL_'], min_length=1, max_item=len(CLUSTERMEMBERS), description='a set of node member that interconnection engage to')
     enable: bool = Field(default=True, description='enable/disable this interconnection')
+    pai: Optional[bool] = Field(default=False, description='send P-Asserted-Identity header on outbound INVITE')
 
     @model_validator(mode='before')
     @classmethod


### PR DESCRIPTION
## Summary

Add a `pai` boolean field to `OutboundInterconnection`. When enabled, LibreSBC injects a `P-Asserted-Identity` header into outbound INVITEs using the post-translation caller ID and the SIP profile advertising IP.

## Use case

Some carriers and downstream SBCs require PAI for CLI validation, especially when the `From` header arrives as `anonymous` from the upstream operator. This makes the feature opt-in per interconnection.

## Changes

- `liberator/libreapi.py`: add `pai: bool = False` field to `OutboundInterconnection` model
- `callng/main.lua`: read `pai` flag from Redis and conditionally export `sip_h_P-Asserted-Identity` before the outbound leg is connected

## Format

```
P-Asserted-Identity: <sip:{caller_id}@{sip_profile_advertising_ip};user=phone>
```