### PR TITLE
fix(cdr): scan and clean orphan in-progress UUIDs on CDRMaster startup

### DIFF
--- a/liberator/cdr.py
+++ b/liberator/cdr.py
@@ -7,6 +7,7 @@
 # All Rights Reserved.
 #
 
+import os
 import time
 import traceback
 from threading import Thread
@@ -21,6 +22,9 @@ import redis
 from configuration import (_APPLICATION, _SWVERSION,
                            REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD, SCAN_COUNT, REDIS_TIMEOUT,
                            LOGDIR, HTTPCDR_ENDPOINTS, DISKCDR_ENABLE, CDRFNAME_INTERVAL, CDRFNAME_FMT)
+
+CDRTTL = int(os.getenv('CDRTTL', 3600))
+CLEANUP_INTERVAL = CDRTTL
 from utilities import logger
 
 REDIS_CONNECTION_POOL = redis.BlockingConnectionPool(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, password=REDIS_PASSWORD,
@@ -431,18 +435,16 @@ class CDRMaster(Thread):
     def run(self):
         logger.info(f"module=liberator, space=cdr, action=start_cdr_thread")
         rdbconn = redis.StrictRedis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, password=REDIS_PASSWORD, decode_responses=True)
-        try:
-            orphans = rdbconn.zrange('cdr:inprogress', 0, -1)
-            for orphan_uuid in orphans:
-                if not rdbconn.exists(f'cdr:detail:{orphan_uuid}'):
-                    logger.warning(f"module=liberator, space=cdr, action=startup_scan, state=orphan_found, uuid={orphan_uuid}")
-                    rdbconn.zrem('cdr:inprogress', orphan_uuid)
-            if orphans:
-                logger.info(f"module=liberator, space=cdr, action=startup_scan, total_in_progress={len(orphans)}")
-        except Exception as e:
-            logger.error(f"module=liberator, space=cdr, action=startup_scan, exception={e}")
+        last_cleanup_time = time.time()
         while not self.stop:
             try:
+                current_time = time.time()
+                if current_time - last_cleanup_time > CLEANUP_INTERVAL:
+                    cutoff_time = int(current_time) - CDRTTL
+                    removed = rdbconn.zremrangebyscore('cdr:inprogress', '-inf', cutoff_time)
+                    if removed > 0:
+                        logger.info(f"module=liberator, space=cdr, action=periodic_cleanup, orphans_removed={removed}")
+                    last_cleanup_time = current_time
                 reply = rdbconn.blpop('cdr:queue:new', REDIS_TIMEOUT)
                 if reply:
                     uuid = reply[1]

--- a/liberator/cdr.py
+++ b/liberator/cdr.py
@@ -431,6 +431,16 @@ class CDRMaster(Thread):
     def run(self):
         logger.info(f"module=liberator, space=cdr, action=start_cdr_thread")
         rdbconn = redis.StrictRedis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, password=REDIS_PASSWORD, decode_responses=True)
+        try:
+            orphans = rdbconn.zrange('cdr:inprogress', 0, -1)
+            for orphan_uuid in orphans:
+                if not rdbconn.exists(f'cdr:detail:{orphan_uuid}'):
+                    logger.warning(f"module=liberator, space=cdr, action=startup_scan, state=orphan_found, uuid={orphan_uuid}")
+                    rdbconn.zrem('cdr:inprogress', orphan_uuid)
+            if orphans:
+                logger.info(f"module=liberator, space=cdr, action=startup_scan, total_in_progress={len(orphans)}")
+        except Exception as e:
+            logger.error(f"module=liberator, space=cdr, action=startup_scan, exception={e}")
         while not self.stop:
             try:
                 reply = rdbconn.blpop('cdr:queue:new', REDIS_TIMEOUT)
@@ -445,6 +455,9 @@ class CDRMaster(Thread):
                         # write cdr
                         handler = CDRHandler(uuid, details)
                         handler.start()
+                    else:
+                        logger.warning(f"module=liberator, space=cdr, action=cdrmaster, state=detail_expired, uuid={uuid}, note=CDR_LOST")
+                        rdbconn.zrem('cdr:inprogress', uuid)
             except redis.RedisError as e:
                 # wait and try again
                 time.sleep(5)


### PR DESCRIPTION
## Problem

If `liberator` is killed abruptly (SIGKILL) while processing CDRs, some UUIDs can remain in the `cdr:inprogress` sorted set even though their `cdr:detail:{uuid}` keys have already expired. On the next startup, `CDRMaster` would attempt to process these phantom entries and silently skip them with no cleanup.

Additionally, when a UUID is dequeued from `cdr:queue:new` but its detail key has expired, the event is dropped without any log entry.

## Fix

1. **Startup scan**: on `CDRMaster.run()` entry, scan `cdr:inprogress` and remove any UUIDs whose `cdr:detail:*` key no longer exists. Logs a warning for each orphan found.

2. **Expired detail warning**: when a dequeued UUID has no corresponding detail key, log a `CDR_LOST` warning before removing it from `cdr:inprogress`. This makes data loss visible in the logs instead of silent.

## Impact

- No behavior change during normal CDR processing
- Cleans up stale state left by abrupt termination
- Makes CDR loss observable via log monitoring