### PR TITLE
feat(libreapi+webui): CDR history tab with date selector and libre_hangup_cause

### DIFF
--- a/liberator/libreapi.py
+++ b/liberator/libreapi.py
@@ -10,6 +10,8 @@
 import traceback
 import re
 import json
+import time
+import os
 import redis
 import validators
 from pydantic import model_validator, StringConstraints, BaseModel, Field
@@ -18,11 +20,12 @@ from typing import Optional, List, Union
 from typing_extensions import Annotated
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network as IPvNetwork
-from fastapi import APIRouter, Response, Path
+from datetime import datetime, timezone
+from fastapi import APIRouter, Response, Path, Query
 from fastapi.encoders import jsonable_encoder
 from configuration import (_APPLICATION, _SWVERSION, _DESCRIPTION, CHANGE_CFG_CHANNEL, SECURITY_CHANNEL,
                            SWCODECS, DFT_CLUSTER_ATTRS, _BUILTIN_ACLS_,
-                           REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD, SCAN_COUNT)
+                           REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD, SCAN_COUNT, LOGDIR)
 from utilities import logger, get_request_uuid, redishash, jsonhash, fieldjsonify, fieldredisify, listify, stringify, getaname, removekey, isjson
 
 REDIS_CONNECTION_POOL = redis.BlockingConnectionPool(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, password=REDIS_PASSWORD,
@@ -2984,5 +2987,76 @@ def delete_routing_record(response: Response, value:str=Path(..., regex=_DIAL_),
     except Exception as e:
         response.status_code, result = 500, None
         logger.error(f"module=liberator, space=libreapi, action=delete_routing_record, requestid={get_request_uuid()}, exception={e}, traceback={traceback.format_exc()}")
+
+    return result
+
+
+#-----------------------------------------------------------------------
+# CDR
+#-----------------------------------------------------------------------
+
+@librerouter.get("/libreapi/cdr/records", status_code=200)
+def get_cdr_records(response: Response, date: str = Query(None), limit: int = Query(200, ge=1, le=2000)):
+    try:
+        if date is None:
+            date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        else:
+            datetime.strptime(date, '%Y-%m-%d')
+
+        cdr_file = os.path.join(LOGDIR, 'cdr', f'{date}.cdr.nice.json')
+        legs = []
+        if os.path.isfile(cdr_file):
+            with open(cdr_file, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        try:
+                            legs.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            pass
+
+        # group by seshid — merge inbound + outbound into one session record
+        sessions = {}
+        for leg in legs:
+            sid = leg.get('seshid') or leg.get('uuid')
+            if sid not in sessions:
+                sessions[sid] = {}
+            direction = leg.get('direction', '')
+            if direction == 'inbound':
+                sessions[sid]['inbound'] = leg
+            elif direction == 'outbound':
+                sessions[sid]['outbound'] = leg
+            else:
+                sessions[sid].setdefault('inbound', leg)
+
+        merged = []
+        for sid, data in sessions.items():
+            ib = data.get('inbound') or {}
+            ob = data.get('outbound') or {}
+            base = ib if ib else ob
+            merged.append({
+                'seshid':      sid,
+                'start_time':  base.get('start_time'),
+                'end_time':    base.get('end_time'),
+                'answer_time': base.get('answer_time'),
+                'duration':    base.get('duration'),
+                'caller_number':      ib.get('caller_number') or ob.get('caller_number'),
+                'destination_number': ib.get('destination_number') or ob.get('destination_number'),
+                'from_intcon': ib.get('intconname'),
+                'to_intcon':   ob.get('intconname'),
+                'gateway':     ob.get('gateway_name'),
+                'hangup_cause': base.get('hangup_cause'),
+                'libre_hangup_cause': base.get('libre_hangup_cause'),
+                'sip_hangup_cause': base.get('sip_hangup_cause'),
+            })
+
+        merged.sort(key=lambda r: int(r.get('end_time') or 0), reverse=True)
+        result = merged[:limit]
+        response.status_code = 200
+    except ValueError:
+        response.status_code, result = 400, {'error': 'Invalid date format, use YYYY-MM-DD'}
+    except Exception as e:
+        response.status_code, result = 500, None
+        logger.error(f"module=liberator, space=libreapi, action=get_cdr_records, requestid={get_request_uuid()}, exception={e}, traceback={traceback.format_exc()}")
 
     return result

--- a/webui/assets/js/site.js
+++ b/webui/assets/js/site.js
@@ -943,3 +943,57 @@ function ShowToast(message, msgtype='danger'){
     document.getElementById('event-message').innerHTML = message;
     $('.toast').toast('show');
 }
+
+// --------------------------------------------------
+// CDR
+// --------------------------------------------------
+
+(function() {
+    var input = document.getElementById('cdr-date-input');
+    if (input) {
+        var today = new Date().toISOString().slice(0, 10);
+        input.value = today;
+        input.max = today;
+    }
+})();
+
+function loadCDR() {
+    var input = document.getElementById('cdr-date-input');
+    var date = input ? input.value : new Date().toISOString().slice(0, 10);
+    $.ajax({
+        type: 'GET',
+        url: '/libreapi/cdr/records?date=' + encodeURIComponent(date) + '&limit=500',
+        success: function(data) {
+            var tbody = document.getElementById('cdr-table-body');
+            var count = document.getElementById('cdr-count');
+            if (!Array.isArray(data) || data.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted">No records</td></tr>';
+                if (count) count.textContent = '';
+                return;
+            }
+            if (count) count.textContent = data.length + ' sessions';
+            var rows = data.map(function(r) {
+                var ts = r.start_time ? new Date(parseInt(r.start_time) * 1000) : null;
+                var timeStr = ts ? ts.toLocaleTimeString() : '-';
+                var dur = parseInt(r.duration) || 0;
+                var durStr = Math.floor(dur / 60) + ':' + String(dur % 60).padStart(2, '0');
+                var answered = r.answer_time && r.answer_time !== '0';
+                var route = (r.from_intcon || '?') + ' → ' + (r.to_intcon || '?');
+                var hangup = r.hangup_cause || '-';
+                var hangupClass = hangup === 'NORMAL_CLEARING' ? 'text-muted' : 'text-danger fw-bold';
+                var libreHangup = r.libre_hangup_cause || '';
+                return '<tr>' +
+                    '<td>' + LSBC.escapeAttr(timeStr) + '</td>' +
+                    '<td>' + LSBC.escapeAttr(r.caller_number || '-') + '</td>' +
+                    '<td>' + LSBC.escapeAttr(r.destination_number || '-') + '</td>' +
+                    '<td class="text-nowrap small">' + LSBC.escapeAttr(route) + '</td>' +
+                    '<td>' + (answered ? durStr : '<span class="text-warning">no answer</span>') + '</td>' +
+                    '<td class="' + hangupClass + '">' + LSBC.escapeAttr(hangup) + '</td>' +
+                    '<td class="text-muted small">' + LSBC.escapeAttr(libreHangup) + '</td>' +
+                    '</tr>';
+            });
+            tbody.innerHTML = rows.join('');
+        },
+        error: function(jqXHR) { LSBC.ajaxError(jqXHR); }
+    });
+}

--- a/webui/index.html
+++ b/webui/index.html
@@ -70,8 +70,12 @@
               </ul>
           </li>
           <li class="nav-item">
-            <a href="" class="nav-link" id="cfg-routing-tab" data-bs-toggle="tab" data-bs-target="#nav-cfg-routing" type="button" 
+            <a href="" class="nav-link" id="cfg-routing-tab" data-bs-toggle="tab" data-bs-target="#nav-cfg-routing" type="button"
             role="tab" aria-controls="nav-cfg-routing" aria-selected="false" onclick="GeneralGetPresent('RoutingTable');">Routing</a>
+          </li>
+          <li class="nav-item">
+            <a href="" class="nav-link" id="cdr-tab" data-bs-toggle="tab" data-bs-target="#nav-cdr" type="button"
+            role="tab" aria-controls="nav-cdr" aria-selected="false" onclick="loadCDR();">CDR</a>
           </li>
           <li class="nav-item">
             <a href="/apidocs" class="nav-link"  type="button" role="tab"><i class="fa  fa-info-circle"></i></a>
@@ -263,6 +267,34 @@
               <!--- END: ROUTING DATA -->                
             </div>
             <!-- END -->
+
+            <!-- CDR -->
+            <div class="tab-pane fade" id="nav-cdr" role="tabpanel" aria-labelledby="cdr-tab">
+              <div class="py-1 text-center"><h3>CDR</h3></div>
+              <hr>
+              <div class="d-flex align-items-center gap-2 mb-3">
+                <input type="date" id="cdr-date-input" class="form-control" style="max-width:180px;">
+                <button type="button" class="btn btn-primary" onclick="loadCDR()"><i class="fa fa-search"></i> Load</button>
+                <span id="cdr-count" class="text-muted small"></span>
+              </div>
+              <div class="table-responsive">
+                <table class="table table-sm table-hover table-striped" id="cdr-table">
+                  <thead class="table-dark">
+                    <tr>
+                      <th>Time</th>
+                      <th>Caller</th>
+                      <th>Destination</th>
+                      <th>Route</th>
+                      <th>Duration</th>
+                      <th>Hangup</th>
+                      <th>Libre Cause</th>
+                    </tr>
+                  </thead>
+                  <tbody id="cdr-table-body"></tbody>
+                </table>
+              </div>
+            </div>
+            <!-- END CDR -->
           </div>
           <!--- PROGRESS BAR -->
           <hr>


### PR DESCRIPTION
## Summary

Adds a CDR history view to the WebUI and a new REST endpoint to query it.

## New endpoint

```
GET /libreapi/cdr/records?date=YYYY-MM-DD&limit=N
```

- Reads the daily NICE-JSON CDR file from `/var/log/libresbc/cdr/{date}.cdr.nice.json`
- Groups inbound + outbound legs by `seshid` into a single session record
- Returns: `seshid`, `start_time`, `end_time`, `answer_time`, `duration`, `caller_number`, `destination_number`, `from_intcon`, `to_intcon`, `gateway`, `hangup_cause`, `libre_hangup_cause`, `sip_hangup_cause`
- Default: today's date, max 200 records (configurable up to 2000)

## WebUI

New **CDR** nav tab:
- Date picker (default today, max today)
- Table: Time | Caller | Destination | Route | Duration | Hangup | Libre Cause
- `libre_hangup_cause` shown alongside the standard `hangup_cause` for easier triage

## Notes

- Read-only; no writes to Redis or disk
- Depends on local CDR logging being enabled (`cdr nice` format)