### PR TITLE
fix(libreapi): handle optional secondary route in routing_table_agreement update path

### DIFF
--- a/liberator/libreapi.py
+++ b/liberator/libreapi.py
@@ -2835,9 +2835,10 @@ class RoutingRecordModel(BaseModel):
                 secondary = routes.get('secondary')
                 load = routes.get('load')
                 if action == _ROUTE:
-                    for intconname in [primary, secondary]:
-                        if not rdbconn.exists(f'intcon:out:{intconname}'):
-                            raise ValueError('nonexistent outbound interconnect')
+                    if not rdbconn.exists(f'intcon:out:{primary}'):
+                        raise ValueError('nonexistent outbound interconnect')
+                    if secondary and not rdbconn.exists(f'intcon:out:{secondary}'):
+                        raise ValueError('nonexistent outbound interconnect')
                 else:
                     for _table in [primary, secondary]:
                         if _table == table:


### PR DESCRIPTION
## Problem

The same bug fixed in #211 (create path, line 2550) also exists in the **update path** of \`routing_table_agreement\` (line 2838).

When updating a routing table with \`action='route'\` and \`secondary=null\`, the validator iterates over \`[primary, secondary]\` without filtering \`None\`:

\`\`\`python
# Before (broken)
for intconname in [primary, secondary]:
    if not rdbconn.exists(f'intcon:out:{intconname}'):
        raise ValueError('nonexistent outbound interconnect')
\`\`\`

When \`secondary\` is \`None\`, this checks \`rdbconn.exists('intcon:out:None')\` → always \`0\` → raises the error on every update without a secondary route.

## Fix

Same pattern applied in #211:

\`\`\`python
# After (fixed)
if not rdbconn.exists(f'intcon:out:{primary}'):
    raise ValueError('nonexistent outbound interconnect')
if secondary and not rdbconn.exists(f'intcon:out:{secondary}'):
    raise ValueError('nonexistent outbound interconnect')
\`\`\`

## Impact

Any user attempting to **update** a routing table without a secondary route hits this bug. The create path was fixed in #211 but the update path was missed.