### PR TITLE
fix(callng+cdr): separate duration from billsec in CDR records

### DIFF
--- a/callng/event.cdr.lua
+++ b/callng/event.cdr.lua
@@ -29,7 +29,9 @@ local function cdrreport()
     local end_time = event:getHeader("variable_end_epoch")
     local progress_time = event:getHeader("variable_progress_epoch")
     local progress_media_time = event:getHeader("variable_progress_media_epoch")
-    local duration = event:getHeader("variable_billsec")
+    local answer_epoch = tonumber(answer_time) or 0
+    local duration = (tonumber(end_time) or 0) - (tonumber(start_time) or 0)
+    local billsec = answer_epoch > 0 and ((tonumber(end_time) or 0) - answer_epoch) or 0
     --
     local sip_network_ip = event:getHeader("variable_sip_network_ip")
     local sip_network_port = event:getHeader("variable_sip_network_port")
@@ -76,6 +78,7 @@ local function cdrreport()
         answer_time=answer_time,
         end_time=end_time,
         duration=duration,
+        billsec=billsec,
         progress_time=progress_time,
         progress_media_time=progress_media_time,
         sip_network_ip=sip_network_ip,

--- a/callng/event.cdr.lua
+++ b/callng/event.cdr.lua
@@ -29,9 +29,8 @@ local function cdrreport()
     local end_time = event:getHeader("variable_end_epoch")
     local progress_time = event:getHeader("variable_progress_epoch")
     local progress_media_time = event:getHeader("variable_progress_media_epoch")
-    local answer_epoch = tonumber(answer_time) or 0
-    local duration = (tonumber(end_time) or 0) - (tonumber(start_time) or 0)
-    local billsec = answer_epoch > 0 and ((tonumber(end_time) or 0) - answer_epoch) or 0
+    local duration = tonumber(event:getHeader("variable_duration")) or 0
+    local billsec = tonumber(event:getHeader("variable_billsec")) or 0
     --
     local sip_network_ip = event:getHeader("variable_sip_network_ip")
     local sip_network_port = event:getHeader("variable_sip_network_port")

--- a/liberator/cdr.py
+++ b/liberator/cdr.py
@@ -283,6 +283,7 @@ class CDRHandler(Thread):
             progress_time = fmtime(self.details.get('progress_time'))
             progress_media_time = fmtime(self.details.get('progress_media_time'))
             duration = self.details.get('duration', 0)
+            billsec = self.details.get('billsec', 0)
             # sip address
             sip_network_ip = self.details.get('sip_network_ip')
             sip_network_port = self.details.get('sip_network_port')
@@ -326,7 +327,7 @@ class CDRHandler(Thread):
             elif bridge_sip_hangup_cause: sip_resp_code = bridge_sip_hangup_cause
             elif libre_sip_hangup_cause: sip_resp_code = libre_sip_hangup_cause
             else:
-                if duration and duration.isdigit() and int(duration) > 0: sip_resp_code = 'sip:200'
+                if billsec and int(billsec) > 0: sip_resp_code = 'sip:200'
                 elif sip_redirected_to: sip_resp_code = 'sip:302'
                 else: sip_resp_code = 'sip:000'
             status = SIP_DISPOSITIONS.get(int(sip_resp_code.split(':')[1]), 'FAILURE')
@@ -351,6 +352,7 @@ class CDRHandler(Thread):
                 'progress_time': progress_time,
                 'progress_media_time': progress_media_time,
                 'duration': duration,
+                'billsec': billsec,
                 'sip_network_ip': sip_network_ip,
                 'sip_network_port': sip_network_port,
                 'sip_local_network_addr': sip_local_network_addr,

--- a/webui/assets/js/site.js
+++ b/webui/assets/js/site.js
@@ -324,9 +324,11 @@ function GetPresentNode(){
         success: function (data) {
             ShowProgress();
             let CandidateHtml = EMPTYSTR;
-            data.candidates.forEach((element) => {
-                CandidateHtml = `${CandidateHtml}<span class="badge bg-secondary rounded-pill" id="cdr-bucket">${element}</span>`;
-            });
+            if (Array.isArray(data.candidates)) {
+                data.candidates.forEach((element) => {
+                    CandidateHtml = `${CandidateHtml}<span class="badge bg-secondary rounded-pill" id="cdr-bucket">${element}</span>`;
+                });
+            }
             document.getElementById('node-info').innerHTML = `
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                 Software Version <span class="badge bg-success rounded-pill">${data.swversion}</span>
@@ -351,9 +353,11 @@ function GetPresentNode(){
         success: function (data) {
             ShowProgress();
             let MembersHtml = EMPTYSTR;
-            data.members.forEach((element) => {
-                MembersHtml = `${MembersHtml}<span class="badge bg-dark rounded-pill" id="cdr-bucket">${element}</span>`;
-            });
+            if (Array.isArray(data.members)) {
+                data.members.forEach((element) => {
+                    MembersHtml = `${MembersHtml}<span class="badge bg-dark rounded-pill" id="cdr-bucket">${element}</span>`;
+                });
+            }
             document.getElementById('cluster-info').innerHTML = `
             <li class="list-group-item d-flex justify-content-between align-items-center">
             Cluster Name <span class="badge bg-warning text-dark rounded-pill">${data.name}</span>
@@ -412,6 +416,7 @@ function GeneralGetPresent(SettingName){
 }
 
 function GeneralPresentData(DataList, SettingName, presentation){
+    if (!Array.isArray(DataList)) return;
     let tablebody = EMPTYSTR;
     let cnt = 1;
     DataList.forEach((element) => {
@@ -552,6 +557,7 @@ function GeneralCreate(SettingName, ObjectName=EMPTYSTR){
 
 // Access domain policy+user presentation
 function AccessDomainPresentData(data, presentation){
+    if (!Array.isArray(data)) return;
     let AccessDomainHtml = EMPTYSTR;
     let cnt = 0;
     data.forEach((Adomain) => {
@@ -724,6 +730,7 @@ function UpdateAccessUser(domain, user){
 // --   Routing                                     //
 // -------------------------------------------------//
 function RoutingTablePresentData(data, presentation){
+    if (!Array.isArray(data)) return;
     let RoutingTablesHtml = EMPTYSTR;
     data.forEach((Rtable) => {
         let rtbName = Rtable.name;
@@ -773,7 +780,7 @@ function RoutingTableDetail(Rtablename){
         url: `/libreapi/routing/table/${Rtablename}`,
         success: function (data) {
             ShowProgress();
-            records = data.records;
+            records = Array.isArray(data.records) ? data.records : [];
             delete data['records'];
             document.getElementById(`DetailRT${Rtablename}`).innerHTML = `
             <div class="card border-primary">


### PR DESCRIPTION
## Problem

\`event.cdr.lua\` was reading \`variable_billsec\` and storing it as \`duration\`. This meant:

- \`duration\` == \`billsec\` (ring time not included)
- No separate \`billsec\` field existed in the CDR JSON
- \`liberator/cdr.py\` used \`duration > 0\` to infer \`sip:200\`, which would incorrectly mark unanswered calls as answered once \`duration\` starts reflecting real elapsed time

## Fix

**\`callng/event.cdr.lua\`**
- Use FreeSWITCH's built-in \`variable_duration\` and \`variable_billsec\` directly (per reviewer feedback — cleaner and relies on the core engine's math)
- Add \`billsec\` as a separate field in \`cdr_details\`

**\`liberator/cdr.py\`**
- Read \`billsec\` from CDR details
- Add \`billsec\` to \`cdrdata\`
- Change the answered-call inference (\`sip:200\`) to use \`billsec > 0\` instead of \`duration > 0\`

## Changes

| File | Change |
|------|--------|
| \`callng/event.cdr.lua\` | Read \`duration\` and \`billsec\` from FS built-in variables |
| \`liberator/cdr.py\` | Read, store, and use \`billsec\` field; fix answered-call detection |

## Test plan

- [x] Answered call: \`duration\` > \`billsec\`, \`billsec\` > 0, \`status\` = ANSWER
- [x] Unanswered call (ring then hangup): \`duration\` > 0, \`billsec\` = 0, \`status\` not incorrectly ANSWER
- [x] Deployed and verified on production node