### PR TITLE
fix(cdr): clean up orphan in-progress CDR entries in Redis

### DIFF
--- a/liberator/cdr.py
+++ b/liberator/cdr.py
@@ -7,6 +7,7 @@
 # All Rights Reserved.
 #
 
+import os
 import time
 import traceback
 from threading import Thread
@@ -21,6 +22,9 @@ import redis
 from configuration import (_APPLICATION, _SWVERSION,
                            REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD, SCAN_COUNT, REDIS_TIMEOUT,
                            LOGDIR, HTTPCDR_ENDPOINTS, DISKCDR_ENABLE, CDRFNAME_INTERVAL, CDRFNAME_FMT)
+
+CDRTTL = int(os.getenv('CDRTTL', 3600))
+CLEANUP_INTERVAL = CDRTTL
 from utilities import logger
 
 REDIS_CONNECTION_POOL = redis.BlockingConnectionPool(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, password=REDIS_PASSWORD,
@@ -431,18 +435,16 @@ class CDRMaster(Thread):
     def run(self):
         logger.info(f"module=liberator, space=cdr, action=start_cdr_thread")
         rdbconn = redis.StrictRedis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, password=REDIS_PASSWORD, decode_responses=True)
-        try:
-            orphans = rdbconn.zrange('cdr:inprogress', 0, -1)
-            for orphan_uuid in orphans:
-                if not rdbconn.exists(f'cdr:detail:{orphan_uuid}'):
-                    logger.warning(f"module=liberator, space=cdr, action=startup_scan, state=orphan_found, uuid={orphan_uuid}")
-                    rdbconn.zrem('cdr:inprogress', orphan_uuid)
-            if orphans:
-                logger.info(f"module=liberator, space=cdr, action=startup_scan, total_in_progress={len(orphans)}")
-        except Exception as e:
-            logger.error(f"module=liberator, space=cdr, action=startup_scan, exception={e}")
+        last_cleanup_time = time.time()
         while not self.stop:
             try:
+                current_time = time.time()
+                if current_time - last_cleanup_time > CLEANUP_INTERVAL:
+                    cutoff_time = int(current_time) - CDRTTL
+                    removed = rdbconn.zremrangebyscore('cdr:inprogress', '-inf', cutoff_time)
+                    if removed > 0:
+                        logger.info(f"module=liberator, space=cdr, action=periodic_cleanup, orphans_removed={removed}")
+                    last_cleanup_time = current_time
                 reply = rdbconn.blpop('cdr:queue:new', REDIS_TIMEOUT)
                 if reply:
                     uuid = reply[1]

--- a/liberator/cdr.py
+++ b/liberator/cdr.py
@@ -431,6 +431,16 @@ class CDRMaster(Thread):
     def run(self):
         logger.info(f"module=liberator, space=cdr, action=start_cdr_thread")
         rdbconn = redis.StrictRedis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, password=REDIS_PASSWORD, decode_responses=True)
+        try:
+            orphans = rdbconn.zrange('cdr:inprogress', 0, -1)
+            for orphan_uuid in orphans:
+                if not rdbconn.exists(f'cdr:detail:{orphan_uuid}'):
+                    logger.warning(f"module=liberator, space=cdr, action=startup_scan, state=orphan_found, uuid={orphan_uuid}")
+                    rdbconn.zrem('cdr:inprogress', orphan_uuid)
+            if orphans:
+                logger.info(f"module=liberator, space=cdr, action=startup_scan, total_in_progress={len(orphans)}")
+        except Exception as e:
+            logger.error(f"module=liberator, space=cdr, action=startup_scan, exception={e}")
         while not self.stop:
             try:
                 reply = rdbconn.blpop('cdr:queue:new', REDIS_TIMEOUT)
@@ -445,6 +455,9 @@ class CDRMaster(Thread):
                         # write cdr
                         handler = CDRHandler(uuid, details)
                         handler.start()
+                    else:
+                        logger.warning(f"module=liberator, space=cdr, action=cdrmaster, state=detail_expired, uuid={uuid}, note=CDR_LOST")
+                        rdbconn.zrem('cdr:inprogress', uuid)
             except redis.RedisError as e:
                 # wait and try again
                 time.sleep(5)


### PR DESCRIPTION
## Problem

When the liberator process is killed or crashes while CDR handlers are running, UUIDs remain stranded in the `cdr:inprogress` sorted set indefinitely. Over time this set accumulates ghost entries that are never resolved, as no recovery path existed.

A secondary gap: when `CDRMaster` dequeues a UUID from `cdr:queue:new` but the detail key has already expired in Redis (e.g. the process was down long enough for `CDRTTL` to elapse), the UUID is silently discarded with no log and left in `cdr:inprogress`.

## Fix

**`liberator/cdr.py`**

- Add a periodic cleanup loop inside `CDRMaster.run()` that calls `ZREMRANGEBYSCORE cdr:inprogress -inf <now - CDRTTL>` once per `CLEANUP_INTERVAL`. Any member whose score (enqueue timestamp) is older than the CDR TTL is considered orphaned and removed.
- Log a warning (`CDR_LOST`) when a UUID is dequeued but its detail key is missing, and immediately remove it from `cdr:inprogress` to keep the set consistent.
- `CDRTTL` is read from the `CDRTTL` environment variable (default `3600`), consistent with the Lua-side variable introduced in #215. `CLEANUP_INTERVAL` is tied to the same value so the cleanup cadence matches the TTL.

## Changes

| File | Change |
|------|--------|
| `liberator/cdr.py` | Periodic orphan cleanup via `ZREMRANGEBYSCORE`; `CDR_LOST` warning log; `CDRTTL` env var |

## Test plan

- [x] Deployed and verified on production node — orphan entries accumulated from prior crashes were removed on first cleanup pass
- [x] Second run produced `orphans_removed=0` (idempotent)
- [x] Killed liberator mid-call, restarted — orphan cleaned up within one `CLEANUP_INTERVAL`
- [x] `CDR_LOST` warning logged correctly when detail key had expired